### PR TITLE
remove johnny-cache

### DIFF
--- a/ccdb/settings_shared.py
+++ b/ccdb/settings_shared.py
@@ -43,13 +43,10 @@ JENKINS_TASKS = (
 
 PROJECT_APPS = ['ccdb.law', ]
 
-JOHNNY_MIDDLEWARE_KEY_PREFIX = 'jc_ccdb'
-
 CACHES = {
     'default': dict(
-        BACKEND='johnny.backends.locmem.LocMemCache',
-        LOCATION='',
-        JOHNNY_CACHE=True,
+        BACKEND='django.core.cache.backends.locmem.LocMemCache',
+        LOCATION='ccdb-unique-snowflake',
     )
 }
 
@@ -76,7 +73,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'djangowind.context.context_processor',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES = [
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -87,8 +84,7 @@ MIDDLEWARE_CLASSES = (
     'impersonate.middleware.ImpersonateMiddleware',
     'waffle.middleware.WaffleMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
-    'johnny.middleware.LocalStoreClearMiddleware',
-    'johnny.middleware.QueryCacheMiddleware', )
+]
 
 ROOT_URLCONF = 'ccdb.urls'
 
@@ -136,6 +132,11 @@ STATSD_PORT = 8125
 
 if 'test' in sys.argv or 'jenkins' in sys.argv:
     STATSD_HOST = '127.0.0.1'
+    CACHES = {
+        'default': dict(
+            BACKEND='django.core.cache.backends.dummy.DummyCache',
+        )
+    }
 
 COMPRESS_URL = "/media/"
 COMPRESS_ROOT = "media/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ ndg-httpsclient==0.4.0
 
 djangowind==0.13.3
 django-tinymce==1.5.3
-johnny-cache==1.6a
 django-indexer==0.3.0
 django-appconf==1.0.1
 django-compressor==1.5


### PR DESCRIPTION
It's not compatible with Django 1.8 and is no longer supported:

https://github.com/jmoiron/johnny-cache/issues/69

I'll experiment with django-cachalot in a bit, but first, just pull
johnny-cache out entirely in favor of plain local memory caching. It won't
be *as* good, but I think our traffic is low enough that we can handle
it for now.