### PR TITLE
Update feedback PMT url

### DIFF
--- a/ccdb/law/smoke.py
+++ b/ccdb/law/smoke.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from smoketest import SmokeTest
 from models import Snapshot
 
@@ -6,3 +7,8 @@ class DBConnectivity(SmokeTest):
     def test_retrieve(self):
         cnt = Snapshot.objects.all().count()
         self.assertTrue(cnt > 0)
+
+
+class RequiredSettings(SmokeTest):
+    def test_pmt_url(self):
+        self.assertTrue(hasattr(settings, 'PMT_EXTERNAL_ADD_ITEM_URL'))

--- a/ccdb/law/views.py
+++ b/ccdb/law/views.py
@@ -34,7 +34,7 @@ class FeedbackView(View):
         if "Role:" not in request.POST.get("description", ""):
             # we know that the javascript was bypassed, so ignore it
             return dict()
-        POST("http://pmt.ccnmtl.columbia.edu/external_add_item.pl",
+        POST(settings.PMT_EXTERNAL_ADD_ITEM_URL,
              params=dict(pid=request.POST['pid'],
                          mid=request.POST['mid'],
                          description=request.POST['description']),

--- a/ccdb/settings_shared.py
+++ b/ccdb/settings_shared.py
@@ -49,6 +49,9 @@ TINYMCE_JS_ROOT = 'media/js/tiny_mce'
 TINYMCE_COMPRESSOR = False
 TINYMCE_SPELLCHECKER = True
 
+PMT_EXTERNAL_ADD_ITEM_URL = ("https://pmt.ccnmtl.columbia.edu"
+                             "/api/external_add_item/")
+
 TINYMCE_DEFAULT_CONFIG = {'cols': 80,
                           'rows': 30,
                           'plugins': 'table,spellchecker,paste,searchreplace',


### PR DESCRIPTION
feedback submission was still pointing to the old `external_add_item.pl` URL, resulting in this: https://sentry.ccnmtl.columbia.edu/sentry-internal/ccdb/group/1058/