### PR TITLE
remove load from future tag from impersonate template

### DIFF
--- a/ccdb/templates/impersonate/list_users.html
+++ b/ccdb/templates/impersonate/list_users.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load url from future %}
 
 {% block content %}
 <h1>Impersonate User List</h1>


### PR DESCRIPTION
to eliminate compress's complaint `impersonate/list_users.html: 'url' is not a valid tag or filter in tag library 'future'`